### PR TITLE
feat: add tag-match input for filtering git describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ We support two types of versions:
   If set to `true`, uses the Git tag as-is for versioning (e.g., `0.1.4`).  
   If `false` or omitted, appends the short Git SHA to the latest tag (e.g., `0.1.4-a1b2c3d`).
 
+- `tag-match`: *(optional)*  
+  Glob passed to `git describe --match` when resolving the latest tag in draft mode. Default `*` matches every tag (previous behaviour).
+  Set this to `v*` (or another pattern) when `refs/tags/*` is shared with non-semver tags — for example, when a deploy pipeline pushes `deploy-<env>-<version>` tags to the same repo. Without a filter, `git describe` will pick those deploy tags as the "latest tag" and produce a polluted version string. Has no effect in release mode (which reads `GITHUB_REF` directly).
+
 ### Outputs
 
 - `draft_version`: Generated version string for draft builds, e.g. `0.1.4-ab12cd3`
@@ -79,6 +83,20 @@ Access with:
 
 ```yaml
 ${{ steps.artefact.outputs.release_version }}
+```
+
+---
+
+#### 🏷️ Filtering tags (e.g. coexisting with deploy tags)
+
+If your repo's `refs/tags/*` namespace contains non-semver tags (deploy markers, environment promotions, etc.), pass `tag-match` so the action only considers semver tags:
+
+```yaml
+- name: Generate Version
+  id: artefact
+  uses: hmcts/artefact-version-action@v1
+  with:
+    tag-match: 'v*'
 ```
 
 ## Release Custom Action

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ We support two types of versions:
   If `false` or omitted, appends the short Git SHA to the latest tag (e.g., `0.1.4-a1b2c3d`).
 
 - `tag-match`: *(optional)*  
-  Glob passed to `git describe --match` when resolving the latest tag in draft mode. Default `*` matches every tag (previous behaviour).
-  Set this to `v*` (or another pattern) when `refs/tags/*` is shared with non-semver tags — for example, when a deploy pipeline pushes `deploy-<env>-<version>` tags to the same repo. Without a filter, `git describe` will pick those deploy tags as the "latest tag" and produce a polluted version string. Has no effect in release mode (which reads `GITHUB_REF` directly).
+  Glob passed to `git describe --match` when resolving the latest tag in draft mode. Default `v*` matches the canonical HMCTS tag format (`vX.Y.Z`) and ignores non-semver tags such as deploy markers.
+  Override with `*` to match any tag, which restores the pre-`tag-match` behaviour (and is what services using non-`v`-prefixed semver tags will need). Has no effect in release mode (which reads `GITHUB_REF` directly).
 
 ### Outputs
 
@@ -87,17 +87,21 @@ ${{ steps.artefact.outputs.release_version }}
 
 ---
 
-#### 🏷️ Filtering tags (e.g. coexisting with deploy tags)
+#### 🏷️ Customising the tag match pattern
 
-If your repo's `refs/tags/*` namespace contains non-semver tags (deploy markers, environment promotions, etc.), pass `tag-match` so the action only considers semver tags:
+The default `tag-match: 'v*'` matches the canonical HMCTS tag format (`vX.Y.Z`) — most consumers don't need to set it. Override it if your repo's tagging convention differs.
+
+To match any tag (the pre-`tag-match` behaviour, useful for repos that tag without a `v` prefix):
 
 ```yaml
 - name: Generate Version
   id: artefact
   uses: hmcts/artefact-version-action@v1
   with:
-    tag-match: 'v*'
+    tag-match: '*'
 ```
+
+Any glob that `git describe --match` accepts is valid (e.g. `release-*`, `app-v*`).
 
 ## Release Custom Action
 

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ inputs:
     required: false
     default: 'false'
   tag-match:
-    description: 'Glob pattern passed to `git describe --match` when resolving the latest tag in draft mode. Use this to filter tags when `refs/tags/*` is shared with non-semver tags (e.g. `v*` to ignore `deploy-*` deploy tags). Default `*` preserves the previous behaviour of matching every tag.'
+    description: 'Glob pattern passed to `git describe --match` when resolving the latest tag in draft mode. Default `v*` matches the canonical HMCTS tag format (`vX.Y.Z`) and ignores non-semver tags such as deploy markers. Override with `*` to match any tag, or any other glob your repo needs.'
     required: false
-    default: '*'
+    default: 'v*'
 outputs:
   draft_version:
     description: 'The generated draft version (e.g., 0.1.4-a1b2c3d)'

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Set to "true" to use the Git tag only (no short SHA). Default is "false".'
     required: false
     default: 'false'
+  tag-match:
+    description: 'Glob pattern passed to `git describe --match` when resolving the latest tag in draft mode. Use this to filter tags when `refs/tags/*` is shared with non-semver tags (e.g. `v*` to ignore `deploy-*` deploy tags). Default `*` preserves the previous behaviour of matching every tag.'
+    required: false
+    default: '*'
 outputs:
   draft_version:
     description: 'The generated draft version (e.g., 0.1.4-a1b2c3d)'
@@ -22,6 +26,7 @@ runs:
       run: ${{ github.action_path }}/entrypoint.sh
       env:
         INPUT_RELEASE: ${{ inputs.release }}
+        INPUT_TAG_MATCH: ${{ inputs.tag-match }}
 branding:
   icon: tag
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,10 +14,12 @@ if [[ "$INPUT_RELEASE" == "true" ]]; then
   echo "release_version=$VERSION" >> "$GITHUB_OUTPUT"
 else
   # Draft mode: Use latest git tag + short SHA, or fallback to default.
-  # INPUT_TAG_MATCH defaults to '*' (match every tag), preserving the
-  # previous behaviour. Callers can pass e.g. 'v*' to filter out tags
-  # that share refs/tags/* but aren't semver (such as deploy markers).
-  TAG_MATCH="${INPUT_TAG_MATCH:-*}"
+  # INPUT_TAG_MATCH defaults to 'v*' to match the canonical HMCTS tag
+  # format (vX.Y.Z) and ignore non-semver tags such as deploy markers
+  # in repos that share refs/tags/*. Callers can pass '*' to match any
+  # tag (the pre-tag-match behaviour) or any other glob their repo
+  # needs.
+  TAG_MATCH="${INPUT_TAG_MATCH:-v*}"
   if LATEST_TAG=$(git describe --tags --abbrev=0 --match="$TAG_MATCH" 2>/dev/null); then
     echo "ℹ️ Latest Git tag resolved to: $LATEST_TAG (match: $TAG_MATCH)"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,12 +13,16 @@ if [[ "$INPUT_RELEASE" == "true" ]]; then
   fi
   echo "release_version=$VERSION" >> "$GITHUB_OUTPUT"
 else
-  # Draft mode: Use latest git tag + short SHA, or fallback to default
-  if LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
-    echo "ℹ️ Latest Git tag resolved to: $LATEST_TAG"
+  # Draft mode: Use latest git tag + short SHA, or fallback to default.
+  # INPUT_TAG_MATCH defaults to '*' (match every tag), preserving the
+  # previous behaviour. Callers can pass e.g. 'v*' to filter out tags
+  # that share refs/tags/* but aren't semver (such as deploy markers).
+  TAG_MATCH="${INPUT_TAG_MATCH:-*}"
+  if LATEST_TAG=$(git describe --tags --abbrev=0 --match="$TAG_MATCH" 2>/dev/null); then
+    echo "ℹ️ Latest Git tag resolved to: $LATEST_TAG (match: $TAG_MATCH)"
   else
     LATEST_TAG="v0.0.0"
-    echo "⚠️ No Git tag found. Falling back to default: $LATEST_TAG"
+    echo "⚠️ No Git tag matching '$TAG_MATCH' found. Falling back to default: $LATEST_TAG"
   fi
 
   LATEST_TAG="${LATEST_TAG#v}"


### PR DESCRIPTION
## Summary

Adds an optional `tag-match` input that's passed straight through to `git describe --match` in draft mode.

**Default: `v*`** — matches the canonical HMCTS tag format (`vX.Y.Z`) already documented in this repo's README.

## Backwards-compatibility nuance

| Consumer's tagging convention | Behaviour today | Behaviour after this PR | Action needed |
|---|---|---|---|
| `vX.Y.Z` (HMCTS canonical) | latest tag picked | latest `v*` tag picked — **identical** | none |
| Non-`v` semver (e.g. `0.1.2`) | `0.1.2` picked | falls back to `v0.0.0` | pass `tag-match: '*'` |
| Mixed (semver + deploy markers, etc.) | latest tag (often the wrong one) | latest `v*` tag — **fixed** | none |

For most consumers this is a clean improvement; for the minority who tag without the `v` prefix it is technically a breaking change. The `*` opt-out restores prior behaviour in one line.

## Motivation

When `refs/tags/*` contains non-semver tags (deploy markers, environment promotions, etc.) the action's unfiltered `git describe --tags --abbrev=0` picks them up as the "latest tag". Concrete failure mode I just hit on `hmcts/courtstranscribe`:

- CD pipeline pushes a deploy tag `deploy-dev-0.1.2-<sha>-<run_id>` to trigger ADO.
- Next run on dev: action returns `deploy-dev-0.1.2-<sha>-<run_id>` as the latest tag, strips the (non-existent) leading `v`, appends short SHA → version = `deploy-dev-0.1.2-<sha>-<run_id>-<new_sha>`.
- That string then gets pushed as the next deploy tag. Pollution grows geometrically each push.

With the `v*` default the action ignores deploy markers; courtstranscribe gets the fix without needing to set anything.

## Changes

- `action.yml`: new optional `tag-match` input with default `v*`. Wired through as `INPUT_TAG_MATCH` env var.
- `entrypoint.sh`: pass `--match="$TAG_MATCH"` (default `v*`) to `git describe`. Log lines mention the match pattern.
- `README.md`: documents the new input and adds a "customising the tag match pattern" usage example.

No effect in release mode — that path reads `GITHUB_REF` directly and isn't affected by `git describe`.

## Smoke test (local)

Tested against throwaway repos:

| Scenario | INPUT_TAG_MATCH | Tags | Result |
|---|---|---|---|
| 1 | (default `v*`) | `v0.1.0`, `v0.1.2` | picks `v0.1.2` |
| 2 | (default `v*`) | `v0.1.0`, `v0.1.2`, `deploy-dev-0.1.2-abc-99999` | picks `v0.1.2` (deploy ignored) |
| 3 | `*` | same as 2 | picks `deploy-dev-0.1.2-abc-99999` (current behaviour) |
| 4 | (default `v*`) | only `0.1.2` (no `v` prefix) | falls back to `v0.0.0` — **regression** for non-v conventions |
| 5 | `*` | only `0.1.2` | picks `0.1.2` (restores prior behaviour) |

## Version bump

Two reasonable options:

- **`v1.0.3`** — treat as a bug-fix-aligning-with-docs (the README has always said `vX.Y.Z`).
- **`v2.0.0`** — strict semver: scenario 4 above is a behaviour change for non-conforming consumers, even if they were misusing the action vs. its documented contract.

I'd lean `v1.0.3` because the README already documented `vX.Y.Z` as canonical, but happy to re-tag as `v2.0.0` if you'd rather be strict. The floating `v1` should still be force-updated either way per the README's release process.

## Test plan

- [ ] Approve and merge.
- [ ] Tag the chosen version, force-update the floating `v1` tag.
- [ ] Verify courtstranscribe no longer needs the strip-tags workaround on its next push to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)